### PR TITLE
Static pages config and guest room page

### DIFF
--- a/src/lib/components/ContentBlock.svelte
+++ b/src/lib/components/ContentBlock.svelte
@@ -1,0 +1,10 @@
+<div class="block">
+	<slot />
+</div>
+
+<style>
+	.block {
+		max-width: 800px;
+		margin: 0 auto 2rem auto;
+	}
+</style>

--- a/src/lib/static-pages/guest-room.md
+++ b/src/lib/static-pages/guest-room.md
@@ -1,0 +1,25 @@
+---
+title: Staying in our guest room
+description: Details on how to stay at the Newspeak House guest room
+---
+
+We keep a guest room at Newspeak House for visiting speakers, faculty, collaborators, and friends of the house. The room is managed by our fellows, and stays are arranged on a flexible, community basis.
+
+**How it works:**
+
+* Priority goes to invited speakers and visiting faculty, but we also welcome external guests when the room is free.  
+* The room is simple but comfortable, with fresh linen and access to our shared kitchen, living areas, and co-working spaces.  
+* We run the space on a **pay-what-you-feel basis** (£30–£80 per night), which covers cleaning and upkeep.  
+* Stays are usually 1–7 nights. Longer visits are possible by special arrangement.
+
+**How to request a stay:** 
+
+Please get in touch with:
+
+* Your name  
+* The dates you’d like to stay (even if flexible)  
+* A short note about who you are and your connection to the community
+
+One of our fellows will be in touch to confirm availability and act as your Host during your stay.
+
+We look forward to welcoming you.

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -11,6 +11,21 @@
 	background-repeat: repeat;
 }
 
+h1,
+h2 {
+	font-family: 'Chalk', sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin: 0 0 1.5rem 0;
+	line-height: 1.2;
+}
+
 p {
 	margin: 0 0 1.5rem 0;
 	line-height: 1.2;
@@ -27,4 +42,12 @@ a {
 
 a:hover {
 	opacity: 0.7;
+}
+
+ul {
+	margin-bottom: 1.5rem;
+}
+
+li {
+	margin-bottom: 0.5rem;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,7 +43,10 @@
 		{/each}
 	</ul>
 
-	<p>Watch this space. Or <a href="library">browse the library</a>. As you like.</p>
+	<p>
+		Watch this space. Or <a href="library">browse the library</a>. Or learn more about
+		<a href="/guest-room">how to stay at the house as a guest</a>. As you like.
+	</p>
 </div>
 
 <style>

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import ContentBlock from '$lib/components/ContentBlock.svelte';
+
+	let { data } = $props();
+
+	console.log('Here is the page data:', data);
+</script>
+
+<svelte:head>
+	<title>{data.pageTitle} · Soli</title>
+	<meta name="description" content={data.pageDescription} />
+</svelte:head>
+
+<div class="main">
+	<ContentBlock>
+		<h2>{data.pageTitle}</h2>
+		<data.pageContent />
+	</ContentBlock>
+</div>
+
+<style>
+	.main {
+		margin: 2rem 0;
+	}
+</style>

--- a/src/routes/[slug]/+page.ts
+++ b/src/routes/[slug]/+page.ts
@@ -1,0 +1,24 @@
+import type { Component } from 'svelte';
+
+export const load = async ({ params }) => {
+	const page = await import(`../../lib/static-pages/${params.slug}.md`);
+
+	console.log('Loaded page module:', page);
+
+	if (!page) {
+		return {
+			status: 404,
+			error: new Error('Not Found')
+		};
+	}
+
+	const pageTitle: string = page.metadata.title;
+	const pageDescription: string = page.metadata.description;
+	const pageContent: Component = page.default;
+
+	return {
+		pageTitle,
+		pageDescription,
+		pageContent
+	};
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,13 +4,13 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: [vitePreprocess(), mdsvex()],
+	preprocess: [vitePreprocess, mdsvex({ extensions: ['.md'] })],
 	kit: {
 		adapter: adapter({
 			fallback: '200.html'
 		})
 	},
-	extensions: ['.svelte', '.svx']
+	extensions: ['.svelte', '.svx', '.md']
 };
 
 export default config;


### PR DESCRIPTION
This rejigs the site to make it easier to add static pages. Now, if you add a markdown file in the `/static-pages` folder with metadata values for `title` and `description` that will automatically become a page on the site.

As a first pass at this I've added info on booking the guest room:

<img width="1898" height="967" alt="image" src="https://github.com/user-attachments/assets/a2c9c89e-8314-4395-ac9e-1d88f575eae9" />

The slug in the url corresponds to the file name, so in this case adding `guest-room.md` creates a page at `https://2025.newspeak.house/guest-room`.

This is only really viable for static text pages, not so much for anything with interactivity.