### PR TITLE
fix: lazy-load assessments to fix 6MB Lambda payload on /awards

### DIFF
--- a/src/routes/awards/+page.svelte
+++ b/src/routes/awards/+page.svelte
@@ -22,6 +22,7 @@
 			versions: Version[];
 			resultsMap: Record<string, Project[]>;
 			resultsMeta?: Record<string, boolean>;
+			hasAssessments?: Record<string, boolean>;
 			currentVersion: string;
 			processLogMarkdown?: string;
 			dataLogMarkdown?: string;
@@ -31,6 +32,7 @@
 	let versions = $state(data.versions as Version[]);
 	let resultsMap = $state(data.resultsMap as Record<string, Project[]>);
 	let resultsMeta = $state((data.resultsMeta ?? {}) as Record<string, boolean>);
+	const hasAssessments = data.hasAssessments ?? {};
 
 	let selectedVersion = $state(data.currentVersion as string);
 
@@ -281,6 +283,48 @@
 		Math.ceil(assessmentLogProjects.length / ALOG_PAGE_SIZE)
 	);
 
+	// Assessment text is lazy-loaded client-side to keep the server payload small.
+	// Cache: version → map of url → { assessment, assessment_synthetic }
+	type AssessmentEntry = { assessment: string; assessment_synthetic: boolean };
+	let assessmentCache = $state<Record<string, Record<string, AssessmentEntry>>>({});
+	let assessmentLoading = $state(false);
+
+	const AWARDS_REPO_RAW = 'https://raw.githubusercontent.com/nwspk/politech-awards-2026/main';
+
+	async function loadAssessments(version: string) {
+		if (assessmentCache[version] !== undefined) return;
+		assessmentLoading = true;
+		try {
+			const res = await fetch(
+				`${AWARDS_REPO_RAW}/iterations/${version}/results.json`,
+				{ cache: 'no-store' }
+			);
+			if (res.ok) {
+				const raw: unknown = await res.json();
+				const items: unknown[] = Array.isArray(raw)
+					? raw
+					: (raw as { projects?: unknown[] })?.projects ?? [];
+				const byUrl: Record<string, AssessmentEntry> = {};
+				for (const x of items) {
+					const item = x as Record<string, unknown>;
+					const url = (item.url ?? item.link ?? '') as string;
+					if (url) {
+						byUrl[url] = {
+							assessment: (item.assessment ?? '') as string,
+							assessment_synthetic: (item.assessment_synthetic ?? false) as boolean
+						};
+					}
+				}
+				assessmentCache = { ...assessmentCache, [version]: byUrl };
+			} else {
+				assessmentCache = { ...assessmentCache, [version]: {} };
+			}
+		} catch {
+			assessmentCache = { ...assessmentCache, [version]: {} };
+		}
+		assessmentLoading = false;
+	}
+
 	onMount(() => {
 		if (!browser) return;
 		const params = new URLSearchParams(window.location.search);
@@ -299,6 +343,10 @@
 		end.setHours(0, 0, 0, 0);
 		const diffMs = end.getTime() - today.getTime();
 		daysRemaining = Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
+
+		// Pre-load assessments for the default assessment-log version
+		const initialAssessmentVersion = versions[0]?.version;
+		if (initialAssessmentVersion) loadAssessments(initialAssessmentVersion);
 	});
 </script>
 
@@ -542,16 +590,15 @@
 
 			<div class="alog-timeline-nav">
 				{#each versions as ver, vi}
-					{@const hasReal = (resultsMap[ver.version] ?? []).some(p => p.assessment && !p.assessment_synthetic)}
 					<button
 						type="button"
 						class="alog-tab"
 						class:alog-tab--active={assessmentLogVersionData?.version === ver.version}
 						style="--tab-color:hsl(var(--{chartColors[vi % chartColors.length]}))"
-						onclick={() => { assessmentLogVersion = ver.version; assessmentLogPage = 0; }}
+						onclick={() => { assessmentLogVersion = ver.version; assessmentLogPage = 0; loadAssessments(ver.version); }}
 					>
 						<span class="alog-tab-ver">{ver.version}</span>
-						{#if hasReal}
+						{#if hasAssessments[ver.version]}
 							<span class="alog-tab-dot alog-tab-dot--real" title="jury/agent assessments available"></span>
 						{:else}
 							<span class="alog-tab-dot alog-tab-dot--synthetic" title="heuristic only"></span>
@@ -562,7 +609,10 @@
 
 			{#if assessmentLogVersionData}
 				{@const activeColor = chartColors[versions.findIndex(v => v.version === assessmentLogVersionData.version) % chartColors.length]}
-				{@const hasSyntheticOnPage = assessmentLogPage_projects.some(p => p.assessment_synthetic)}
+				{@const versionAssessmentMap = assessmentCache[assessmentLogVersionData.version]}
+				{@const hasSyntheticOnPage = versionAssessmentMap
+					? assessmentLogPage_projects.some(p => versionAssessmentMap[p.url]?.assessment_synthetic)
+					: false}
 				<div class="alog-panel" style="border-left-color:hsl(var(--{activeColor}))">
 					<div class="alog-panel-header">
 						<span class="alog-panel-ver" style="color:hsl(var(--{activeColor}))">{assessmentLogVersionData.version}</span>
@@ -572,6 +622,7 @@
 
 					<div class="alog-project-list">
 						{#each assessmentLogPage_projects as project}
+							{@const cached = versionAssessmentMap?.[project.url]}
 							<div class="alog-project" style="border-left-color:hsl(var(--{activeColor}))">
 								<div class="alog-project-meta">
 									<span class="alog-project-rank">#{project.rank}</span>
@@ -581,8 +632,10 @@
 								{#if project.summary}
 									<p class="alog-project-summary">{project.summary}</p>
 								{/if}
-								{#if project.assessment}
-									<p class="alog-project-assessment">{project.assessment}{project.assessment_synthetic ? ' *' : ''}</p>
+								{#if cached?.assessment}
+									<p class="alog-project-assessment">{cached.assessment}{cached.assessment_synthetic ? ' *' : ''}</p>
+								{:else if versionAssessmentMap === undefined && assessmentLoading}
+									<p class="alog-project-assessment alog-loading">Loading assessments…</p>
 								{/if}
 							</div>
 						{/each}
@@ -1786,6 +1839,10 @@
 		line-height: 1.6;
 		color: rgba(26, 26, 26, 0.82);
 		margin: 0;
+	}
+	.alog-loading {
+		color: rgba(26, 26, 26, 0.4);
+		font-style: italic;
 	}
 	.alog-pagination {
 		display: flex;

--- a/src/routes/awards/+page.ts
+++ b/src/routes/awards/+page.ts
@@ -85,8 +85,9 @@ function toProjects(repoResults: RepoResult[]): Project[] {
 		name: r.name ?? urlToName(r.url),
 		url: r.url,
 		summary: r.summary ?? '',
-		assessment: r.assessment ?? '',
-		assessment_synthetic: r.assessment_synthetic ?? false
+		// assessment text omitted from server payload — loaded client-side on demand
+		assessment: '',
+		assessment_synthetic: false
 	}));
 }
 
@@ -108,13 +109,19 @@ export const load: PageLoad = async ({ fetch }) => {
 	const fallbackProjects = toProjects(toRepoResults(mainData));
 
 	const resultsMap: Record<string, { projects: Project[]; isFallback: boolean }> = {};
+	// Track which versions have real (non-synthetic) per-project assessments
+	const hasAssessments: Record<string, boolean> = {};
+
 	for (let i = 0; i < versionIds.length; i++) {
 		const ver = versionIds[i];
 		const res = versionResponses[i];
 		if (res?.ok) {
 			const data = await res.json();
-			resultsMap[ver] = { projects: toProjects(toRepoResults(data)), isFallback: false };
+			const rr = toRepoResults(data);
+			hasAssessments[ver] = rr.some((r) => r.assessment && !r.assessment_synthetic);
+			resultsMap[ver] = { projects: toProjects(rr), isFallback: false };
 		} else {
+			hasAssessments[ver] = false;
 			resultsMap[ver] = { projects: fallbackProjects, isFallback: true };
 		}
 	}
@@ -152,15 +159,13 @@ export const load: PageLoad = async ({ fetch }) => {
 		resultsMeta[v] = resultsMap[v].isFallback;
 	}
 
-	const [processLogRes, iterationsLogRes, dataLogRes] = await Promise.all([
+	const [processLogRes, dataLogRes] = await Promise.all([
 		fetch(`${LOGS_BASE}/process-log.md`, FETCH_OPTS),
-		fetch(`${LOGS_BASE}/iterations-log.md`, FETCH_OPTS),
 		fetch(`${LOGS_BASE}/data-log.md`, FETCH_OPTS)
 	]);
 
-	const [processLogMarkdown, iterationsLogMarkdown, dataLogMarkdown] = await Promise.all([
+	const [processLogMarkdown, dataLogMarkdown] = await Promise.all([
 		processLogRes.ok ? processLogRes.text() : Promise.resolve(''),
-		iterationsLogRes.ok ? iterationsLogRes.text() : Promise.resolve(''),
 		dataLogRes.ok ? dataLogRes.text() : Promise.resolve('')
 	]);
 
@@ -168,10 +173,9 @@ export const load: PageLoad = async ({ fetch }) => {
 		versions,
 		resultsMap: resultsMapFlat,
 		resultsMeta,
+		hasAssessments,
 		currentVersion,
-		totalCount: fallbackProjects.length,
 		processLogMarkdown,
-		iterationsLogMarkdown,
 		dataLogMarkdown
 	};
 };


### PR DESCRIPTION
## Problem

`/awards` was returning a 502 on Netlify. Two compounding causes:

**1. `Function.ResponseSizeTooLarge`** — `v11/results.json` is 1.5MB of per-agent rationale text (321 projects × 17 agents). `main/results.json` is another 1.5MB. The old code fetched all 12 version files server-side and serialised everything into the page, pushing the SSR response past Netlify's 6MB Lambda limit.

**2. Lambda timeout** — even after fixing the payload size, the server was making 15 sequential/parallel fetches to `raw.githubusercontent.com`. Measured from an external host: `v11/results.json` takes ~4s, `process-log.md` takes ~3s. Fetching them sequentially would exceed the 10s Lambda limit.

**Root cause of both:** the old architecture fetched everything from GitHub raw on every request and returned it all in one SSR response.

## Fix

**Stop doing heavy work in the Lambda entirely — prerender the page at build time.**

With lazy-loading in place, the build-time fetch is minimal:
- `iterations.json` — 60KB
- current version's `results.json` — one file, fetched in parallel with the logs
- `process-log.md` + `data-log.md` — 30KB combined

Everything else (other versions' scores, all assessment text) loads client-side on first access.

At runtime there is no Lambda at all — Netlify serves a static HTML file from CDN. No 6MB limit. No 10s timeout.

## What changed (4 commits)

| Commit | What |
|---|---|
| `e7b4be8` | Strip `assessment` text from `toProjects()` server-side; add `hasAssessments` map; drop unused `iterationsLogMarkdown` fetch |
| `3defcff` | Only load **current version's** results.json server-side (not all 12); all other versions lazy-load client-side via `ensureVersionLoaded()`; new `$lib/utils/awards-results.ts` shared between server and client |
| `ce16b40` | Parallelize the remaining server fetches (current results + log files) in one `Promise.all` instead of sequential awaits |
| `1f78e0b` | `prerender = true` — eliminates the Lambda entirely; build fetches once, Netlify serves static HTML |

## Why prerender works now but didn't before

The old code tried to bake all 12 versions × ~300 projects × full assessment text into the HTML at build time — a multi-MB static file that would fail to generate. The new code only bakes the current version's scores (~200KB total). Everything else is client-side.

## Trade-off

The page reflects data as of the last site build. It won't auto-update when `politech-awards-2026` gets a new merge. To fix that: add a webhook in `politech-awards-2026` that triggers a Netlify rebuild on push to main.