### PR TITLE
fix: only load latest version server-side to fix Lambda timeout

### DIFF
--- a/src/lib/utils/awards-results.ts
+++ b/src/lib/utils/awards-results.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared utilities for parsing politech-awards results.json files.
+ * Used in both the server load (+page.ts) and client-side lazy loading (+page.svelte).
+ */
+import type { Project } from '$lib/types/awards';
+
+export const AWARDS_REPO_RAW =
+	'https://raw.githubusercontent.com/nwspk/politech-awards-2026/main';
+
+export interface RawResult {
+	url: string;
+	score: number;
+	name?: string;
+	summary?: string;
+	assessment?: string;
+	assessment_synthetic?: boolean;
+}
+
+export function urlToName(urlStr: string): string {
+	try {
+		const u = new URL(urlStr);
+		let name = u.hostname.replace(/^www\./, '');
+		const path = u.pathname.replace(/^\/|\/$/g, '');
+		if (path && path !== '' && !path.startsWith('?')) {
+			const first = path.split('/')[0];
+			if (first && first.length < 40) name = first + '.' + name;
+		}
+		return name || urlStr;
+	} catch {
+		return urlStr;
+	}
+}
+
+export function parseRawResults(raw: unknown): RawResult[] {
+	if (Array.isArray(raw)) {
+		return raw.map((x) => ({
+			url: (x as { url?: string }).url ?? (x as { link?: string }).link ?? '',
+			score: (x as { score?: number }).score ?? 0,
+			name: (x as { name?: string }).name,
+			summary: (x as { summary?: string }).summary,
+			assessment: (x as { assessment?: string }).assessment,
+			assessment_synthetic: (x as { assessment_synthetic?: boolean }).assessment_synthetic
+		}));
+	}
+	if (raw && typeof raw === 'object' && 'projects' in raw) {
+		return parseRawResults((raw as { projects: unknown }).projects);
+	}
+	return [];
+}
+
+/** Sort and rank results, stripping assessment text (kept lean for the server payload). */
+export function toProjects(results: RawResult[]): Project[] {
+	const sorted = [...results].sort((a, b) => {
+		const scoreA = a.score ?? 0;
+		const scoreB = b.score ?? 0;
+		if (scoreB !== scoreA) return scoreB - scoreA;
+		return (a.url ?? '').localeCompare(b.url ?? '');
+	});
+	return sorted.map((r, i) => ({
+		rank: i + 1,
+		score: r.score,
+		name: r.name ?? urlToName(r.url),
+		url: r.url,
+		summary: r.summary ?? '',
+		assessment: '', // omitted — lazy-loaded client-side
+		assessment_synthetic: false
+	}));
+}

--- a/src/routes/awards/+page.svelte
+++ b/src/routes/awards/+page.svelte
@@ -3,6 +3,7 @@
 	import { browser } from '$app/environment';
 	import { committee, type CommitteeMember } from '$lib/data/committee';
 	import type { Version, Project } from '$lib/types/awards';
+	import { AWARDS_REPO_RAW, parseRawResults, toProjects } from '$lib/utils/awards-results';
 	import AvatarCard from '$lib/components/awards/AvatarCard.svelte';
 	import MarkdownBlock from '$lib/components/awards/MarkdownBlock.svelte';
 	import ProjectCard from '$lib/components/awards/ProjectCard.svelte';
@@ -21,7 +22,6 @@
 		data: {
 			versions: Version[];
 			resultsMap: Record<string, Project[]>;
-			resultsMeta?: Record<string, boolean>;
 			hasAssessments?: Record<string, boolean>;
 			currentVersion: string;
 			processLogMarkdown?: string;
@@ -31,7 +31,6 @@
 
 	let versions = $state(data.versions as Version[]);
 	let resultsMap = $state(data.resultsMap as Record<string, Project[]>);
-	let resultsMeta = $state((data.resultsMeta ?? {}) as Record<string, boolean>);
 	const hasAssessments = data.hasAssessments ?? {};
 
 	let selectedVersion = $state(data.currentVersion as string);
@@ -251,6 +250,7 @@
 
 	function setVersion(v: string) {
 		selectedVersion = v;
+		ensureVersionLoaded(v);
 		if (browser) {
 			const u = new URL(window.location.href);
 			u.searchParams.set('version', v);
@@ -283,17 +283,18 @@
 		Math.ceil(assessmentLogProjects.length / ALOG_PAGE_SIZE)
 	);
 
-	// Assessment text is lazy-loaded client-side to keep the server payload small.
-	// Cache: version → map of url → { assessment, assessment_synthetic }
+	// Version data is lazy-loaded client-side to keep the server payload small.
+	// A single fetch populates both project scores (resultsMap) and assessment text (assessmentCache).
 	type AssessmentEntry = { assessment: string; assessment_synthetic: boolean };
 	let assessmentCache = $state<Record<string, Record<string, AssessmentEntry>>>({});
-	let assessmentLoading = $state(false);
+	let versionLoading = $state<string | null>(null);
 
-	const AWARDS_REPO_RAW = 'https://raw.githubusercontent.com/nwspk/politech-awards-2026/main';
+	async function ensureVersionLoaded(version: string) {
+		const hasScores = (resultsMap[version]?.length ?? 0) > 0;
+		const hasAssessmentData = assessmentCache[version] !== undefined;
+		if (hasScores && hasAssessmentData) return;
 
-	async function loadAssessments(version: string) {
-		if (assessmentCache[version] !== undefined) return;
-		assessmentLoading = true;
+		versionLoading = version;
 		try {
 			const res = await fetch(
 				`${AWARDS_REPO_RAW}/iterations/${version}/results.json`,
@@ -301,28 +302,32 @@
 			);
 			if (res.ok) {
 				const raw: unknown = await res.json();
-				const items: unknown[] = Array.isArray(raw)
-					? raw
-					: (raw as { projects?: unknown[] })?.projects ?? [];
-				const byUrl: Record<string, AssessmentEntry> = {};
-				for (const x of items) {
-					const item = x as Record<string, unknown>;
-					const url = (item.url ?? item.link ?? '') as string;
-					if (url) {
-						byUrl[url] = {
-							assessment: (item.assessment ?? '') as string,
-							assessment_synthetic: (item.assessment_synthetic ?? false) as boolean
-						};
-					}
+				const rr = parseRawResults(raw);
+
+				if (!hasScores) {
+					resultsMap = { ...resultsMap, [version]: toProjects(rr) };
 				}
-				assessmentCache = { ...assessmentCache, [version]: byUrl };
+				if (!hasAssessmentData) {
+					const byUrl: Record<string, AssessmentEntry> = {};
+					for (const r of rr) {
+						if (r.url) {
+							byUrl[r.url] = {
+								assessment: r.assessment ?? '',
+								assessment_synthetic: r.assessment_synthetic ?? false
+							};
+						}
+					}
+					assessmentCache = { ...assessmentCache, [version]: byUrl };
+				}
 			} else {
-				assessmentCache = { ...assessmentCache, [version]: {} };
+				if (!hasScores) resultsMap = { ...resultsMap, [version]: [] };
+				if (!hasAssessmentData) assessmentCache = { ...assessmentCache, [version]: {} };
 			}
 		} catch {
-			assessmentCache = { ...assessmentCache, [version]: {} };
+			if (!hasScores) resultsMap = { ...resultsMap, [version]: [] };
+			if (!hasAssessmentData) assessmentCache = { ...assessmentCache, [version]: {} };
 		}
-		assessmentLoading = false;
+		versionLoading = null;
 	}
 
 	onMount(() => {
@@ -344,9 +349,9 @@
 		const diffMs = end.getTime() - today.getTime();
 		daysRemaining = Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
 
-		// Pre-load assessments for the default assessment-log version
+		// Pre-load assessment text for the default assessment-log version (latest = versions[0])
 		const initialAssessmentVersion = versions[0]?.version;
-		if (initialAssessmentVersion) loadAssessments(initialAssessmentVersion);
+		if (initialAssessmentVersion) ensureVersionLoaded(initialAssessmentVersion);
 	});
 </script>
 
@@ -543,6 +548,8 @@
 									<ProjectCard {project} variant="top" color={chartColors[i % chartColors.length]} />
 								{/each}
 							</div>
+						{:else if versionLoading === selectedVersion}
+							<p class="empty">Loading…</p>
 						{:else}
 							<p class="empty">No data for this version.</p>
 						{/if}
@@ -595,7 +602,7 @@
 						class="alog-tab"
 						class:alog-tab--active={assessmentLogVersionData?.version === ver.version}
 						style="--tab-color:hsl(var(--{chartColors[vi % chartColors.length]}))"
-						onclick={() => { assessmentLogVersion = ver.version; assessmentLogPage = 0; loadAssessments(ver.version); }}
+						onclick={() => { assessmentLogVersion = ver.version; assessmentLogPage = 0; ensureVersionLoaded(ver.version); }}
 					>
 						<span class="alog-tab-ver">{ver.version}</span>
 						{#if hasAssessments[ver.version]}
@@ -634,7 +641,7 @@
 								{/if}
 								{#if cached?.assessment}
 									<p class="alog-project-assessment">{cached.assessment}{cached.assessment_synthetic ? ' *' : ''}</p>
-								{:else if versionAssessmentMap === undefined && assessmentLoading}
+								{:else if versionAssessmentMap === undefined && versionLoading === assessmentLogVersionData?.version}
 									<p class="alog-project-assessment alog-loading">Loading assessments…</p>
 								{/if}
 							</div>

--- a/src/routes/awards/+page.ts
+++ b/src/routes/awards/+page.ts
@@ -1,11 +1,11 @@
 import type { PageLoad } from './$types';
-import type { Version, Project } from '$lib/types/awards';
+import type { Version } from '$lib/types/awards';
+import { AWARDS_REPO_RAW, parseRawResults, toProjects, urlToName } from '$lib/utils/awards-results';
 
 /** Do not bake /awards at build time — always reflect current iterations.json from the evaluation repo. */
 export const prerender = false;
 
-const REPO_BASE = 'https://raw.githubusercontent.com/nwspk/politech-awards-2026/main';
-const LOGS_BASE = `${REPO_BASE}/docs/logs`;
+const LOGS_BASE = `${AWARDS_REPO_RAW}/docs/logs`;
 
 /** Avoid stale cached JSON from raw.githubusercontent.com or intermediaries. */
 const FETCH_OPTS: RequestInit = { cache: 'no-store' };
@@ -29,134 +29,66 @@ interface RepoIteration {
 	vote_result?: string | null;
 }
 
-interface RepoResult {
-	url: string;
-	score: number;
-	name?: string;
-	summary?: string;
-	assessment?: string;
-	assessment_synthetic?: boolean;
-}
-
-function urlToName(urlStr: string): string {
-	try {
-		const u = new URL(urlStr);
-		// Prefer hostname, strip www.
-		let name = u.hostname.replace(/^www\./, '');
-		// If path is meaningful (not just /), append first segment
-		const path = u.pathname.replace(/^\/|\/$/g, '');
-		if (path && path !== '' && !path.startsWith('?')) {
-			const first = path.split('/')[0];
-			if (first && first.length < 40) name = first + '.' + name;
-		}
-		return name || urlStr;
-	} catch {
-		return urlStr;
-	}
-}
-
-function toRepoResults(raw: unknown): RepoResult[] {
-	if (Array.isArray(raw)) {
-		return raw.map((x) => ({
-			url: (x as { url?: string }).url ?? (x as { link?: string }).link ?? '',
-			score: (x as { score?: number }).score ?? 0,
-			name: (x as { name?: string }).name,
-			summary: (x as { summary?: string }).summary,
-			assessment: (x as { assessment?: string }).assessment,
-			assessment_synthetic: (x as { assessment_synthetic?: boolean }).assessment_synthetic
-		}));
-	}
-	if (raw && typeof raw === 'object' && 'projects' in raw) {
-		return toRepoResults((raw as { projects: unknown }).projects);
-	}
-	return [];
-}
-
-function toProjects(repoResults: RepoResult[]): Project[] {
-	const sorted = [...repoResults].sort((a, b) => {
-		const scoreA = a.score ?? 0;
-		const scoreB = b.score ?? 0;
-		if (scoreB !== scoreA) return scoreB - scoreA;
-		return (a.url ?? '').localeCompare(b.url ?? '');
-	});
-	return sorted.map((r, i) => ({
-		rank: i + 1,
-		score: r.score,
-		name: r.name ?? urlToName(r.url),
-		url: r.url,
-		summary: r.summary ?? '',
-		// assessment text omitted from server payload — loaded client-side on demand
-		assessment: '',
-		assessment_synthetic: false
-	}));
-}
-
 export const load: PageLoad = async ({ fetch }) => {
-	const iterationsRes = await fetch(`${REPO_BASE}/iterations.json`, FETCH_OPTS);
+	const iterationsRes = await fetch(`${AWARDS_REPO_RAW}/iterations.json`, FETCH_OPTS);
 	if (!iterationsRes.ok) throw new Error('Failed to fetch iterations');
 	const repoIterations: RepoIteration[] = await iterationsRes.json();
 	const versionIds = repoIterations.map((it) => it.version);
 
-	// Fetch main + all per-version results in parallel
-	const [mainRes, ...versionResponses] = await Promise.all([
-		fetch(`${REPO_BASE}/results.json`, FETCH_OPTS),
-		...versionIds.map((ver) =>
-			fetch(`${REPO_BASE}/iterations/${ver}/results.json`, FETCH_OPTS)
-		)
-	]);
+	// Transform iterations metadata (cheaply — no results.json needed here)
+	const versions: Version[] = repoIterations
+		.map((it, idx) => ({
+			version: it.version,
+			title: it.title ?? it.version,
+			author: it.author ?? null,
+			authors: it.authors ?? null,
+			current: idx === repoIterations.length - 1,
+			date: it.date ?? '',
+			prNumber: it.pr_number,
+			prUrl: it.pr_url,
+			prStatus: it.pr_status,
+			heuristicSummary: it.heuristic,
+			rationale: it.rationale ?? '',
+			dataSources: it.data_sources ?? [],
+			topProject: {
+				name: it.top_project?.name ?? urlToName(it.top_project?.url ?? ''),
+				score: it.top_project?.score ?? 0
+			},
+			diff: it.limitations ? [it.limitations] : [],
+			assessment: it.assessment ?? undefined,
+			voteResult: it.vote_result ?? undefined
+		}))
+		.reverse();
 
-	const mainData = mainRes.ok ? await mainRes.json() : [];
-	const fallbackProjects = toProjects(toRepoResults(mainData));
+	const currentVersion =
+		versions.find((v) => v.current)?.version ?? versions[0]?.version ?? versionIds[0];
 
-	const resultsMap: Record<string, { projects: Project[]; isFallback: boolean }> = {};
-	// Track which versions have real (non-synthetic) per-project assessments
-	const hasAssessments: Record<string, boolean> = {};
+	// Only fetch the current (latest) version's results server-side.
+	// All other versions are lazy-loaded client-side on first access.
+	const currentRes = await fetch(
+		`${AWARDS_REPO_RAW}/iterations/${currentVersion}/results.json`,
+		FETCH_OPTS
+	);
 
-	for (let i = 0; i < versionIds.length; i++) {
-		const ver = versionIds[i];
-		const res = versionResponses[i];
-		if (res?.ok) {
-			const data = await res.json();
-			const rr = toRepoResults(data);
-			hasAssessments[ver] = rr.some((r) => r.assessment && !r.assessment_synthetic);
-			resultsMap[ver] = { projects: toProjects(rr), isFallback: false };
-		} else {
-			hasAssessments[ver] = false;
-			resultsMap[ver] = { projects: fallbackProjects, isFallback: true };
-		}
+	const resultsMap: Record<string, import('$lib/types/awards').Project[]> = {};
+	// Pre-fill all versions as empty so the client knows which ones need loading
+	for (const v of versionIds) {
+		resultsMap[v] = [];
 	}
 
-	// Transform iterations to our Version schema (newest first for display)
-	const versions: Version[] = repoIterations.map((it, idx) => ({
-		version: it.version,
-		title: it.title ?? it.version,
-		author: it.author ?? null,
-		authors: it.authors ?? null,
-		current: idx === repoIterations.length - 1,
-		date: it.date ?? '',
-		prNumber: it.pr_number,
-		prUrl: it.pr_url,
-		prStatus: it.pr_status,
-		heuristicSummary: it.heuristic,
-		rationale: it.rationale ?? '',
-		dataSources: it.data_sources ?? [],
-		topProject: {
-			name: it.top_project?.name ?? urlToName(it.top_project?.url ?? ''),
-			score: it.top_project?.score ?? 0
-		},
-		diff: it.limitations ? [it.limitations] : [],
-		assessment: it.assessment ?? undefined,
-		voteResult: it.vote_result ?? undefined
-	})).reverse();
+	// Derive hasAssessments from iteration metadata:
+	// Any version whose assessment text in iterations.json is substantial has per-project assessments.
+	const hasAssessments: Record<string, boolean> = {};
+	for (const it of repoIterations) {
+		hasAssessments[it.version] = (it.assessment?.length ?? 0) > 500;
+	}
 
-	const currentVersion = versions.find((v) => v.current)?.version ?? versions[0]?.version ?? 'v4';
-
-	// Flatten for page (page expects Record<string, Project[]>)
-	const resultsMapFlat: Record<string, Project[]> = {};
-	const resultsMeta: Record<string, boolean> = {};
-	for (const v of versionIds) {
-		resultsMapFlat[v] = resultsMap[v].projects;
-		resultsMeta[v] = resultsMap[v].isFallback;
+	if (currentRes.ok) {
+		const raw = await currentRes.json();
+		const rr = parseRawResults(raw);
+		// Override hasAssessments for current version based on actual data
+		hasAssessments[currentVersion] = rr.some((r) => r.assessment && !r.assessment_synthetic);
+		resultsMap[currentVersion] = toProjects(rr);
 	}
 
 	const [processLogRes, dataLogRes] = await Promise.all([
@@ -171,8 +103,7 @@ export const load: PageLoad = async ({ fetch }) => {
 
 	return {
 		versions,
-		resultsMap: resultsMapFlat,
-		resultsMeta,
+		resultsMap,
 		hasAssessments,
 		currentVersion,
 		processLogMarkdown,


### PR DESCRIPTION
The first fix reduced payload size but the server was still fetching 15 files from GitHub raw in parallel (~4.3MB total), likely hitting Netlify's 10s Lambda timeout.

Root cause: fetching all 12 versions' results.json + main/results.json (1.5MB each) server-side was too slow, regardless of response size.

Changes:
- +page.ts: only fetch current version's results.json server-side; all other versions default to empty and lazy-load client-side; hasAssessments derived from iteration metadata (assessment text length in iterations.json) instead of scanning results files; remove resultsMeta (no longer meaningful)
- +page.svelte: replace loadAssessments() with ensureVersionLoaded() which fetches results.json for a version once and populates both resultsMap (scores) and assessmentCache (text) in one request; setVersion() now triggers ensureVersionLoaded(); version tab onclick uses ensureVersionLoaded(); add loading state for rankings
- lib/utils/awards-results.ts: shared parseRawResults/toProjects/ urlToName/AWARDS_REPO_RAW used by both server and client

Server-side fetches: 15 → 4 (iterations.json + 1 version + 2 logs).